### PR TITLE
Handle attack schema 2.1, damage with overheal

### DIFF
--- a/blueprints/characters.py
+++ b/blueprints/characters.py
@@ -75,6 +75,10 @@ class ValidationError(Exception):
     pass
 
 
+REQUIRED_ATTACK_KEYS = {"name", "automation", "_v"}
+OPTIONAL_ATTACK_KEYS = {"proper", "verb"}
+
+
 def _validate_attacks(the_attacks):
     if not isinstance(the_attacks, list):
         raise ValidationError("Attacks must be a list")
@@ -85,7 +89,8 @@ def _validate_attacks(the_attacks):
         if not isinstance(attack, dict):
             raise ValidationError(template.format(i, "attack is not an object"))
 
-        if not set(attack.keys()) == {"name", "automation", "_v"}:
+        keys = set(attack.keys())
+        if not (keys.issuperset(REQUIRED_ATTACK_KEYS) and keys.issubset(REQUIRED_ATTACK_KEYS | OPTIONAL_ATTACK_KEYS)):
             raise ValidationError(template.format(i, "attack object missing keys"))
 
         if not is_valid_automation(attack['automation']):

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -66,6 +66,9 @@ def check_save(effect):
 
 def check_damage(effect):
     assert 'damage' in effect, "Damage effect must have damage"
+    if 'overheal' in effect:
+        assert isinstance(effect['overheal'], bool) or effect['overheal'] is None, \
+            "Overheal must be boolean"
     if 'higher' in effect:
         check_higher(effect['higher'])
     if 'cantripScale' in effect:


### PR DESCRIPTION
Ensures that the API accepts attacks with the 2.1 schema (updated in monster attacks), and adds supports for damage effects with overheal.

Resolves avrae/avrae.io#129