### PR TITLE
API-001 delete homebrew subscriptions when object is deleted

### DIFF
--- a/blueprints/homebrew/items.py
+++ b/blueprints/homebrew/items.py
@@ -106,6 +106,7 @@ def delete_pack(pack):
     if not _is_owner(user, ObjectId(pack)):
         return "You do not have permission to delete this pack", 403
     current_app.mdb.packs.delete_one({"_id": ObjectId(pack)})
+    current_app.mdb.pack_subscriptions.delete_many({"object_id": ObjectId(pack)})
     return "Pack deleted."
 
 

--- a/blueprints/homebrew/spells.py
+++ b/blueprints/homebrew/spells.py
@@ -112,6 +112,7 @@ def delete_tome(tome):
     if not _is_owner(user, ObjectId(tome)):
         return "You do not have permission to delete this tome", 403
     current_app.mdb.tomes.delete_one({"_id": ObjectId(tome)})
+    current_app.mdb.tome_subscriptions.delete_many({"object_id": ObjectId(tome)})
     return "Tome deleted."
 
 


### PR DESCRIPTION
Resolves #18

Ensures subscription objects to a homebrew collection object are removed when the collection object is removed. This was the root cause of avrae/avrae#934 (fixed in a clientside patch before).