### PR TITLE
Refactor Workshop Explore queries to use ElasticSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ The development config defaults to the MongoDB/Redis servers run by [Avrae](http
 1. Copy `docker/config-development.py` to `config.py`.
 2. Set the environment variables `AVRAE_MONGO_URL` and `AVRAE_REDIS_URL`, or change `test_mongo_url` and `test_redis_url` in `config.py`. 
 
+### ElasticSearch
+
+The Avrae service requires ElasticSearch for some features (e.g. searching alias workshop collections). You
+should either set up a dev ElasticSearch instance on AWS, or run an openElasticSearch distro.
+
+Whichever you choose, set the `ELASTICSEARCH_ENDPOINT` env var.
+
 ### Running locally
 
 1. Create a [virtual environment](https://docs.python.org/3/library/venv.html): `python3 -m venv venv`.

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from blueprints.homebrew.items import items
 from blueprints.homebrew.spells import spells
 from blueprints.workshop import workshop
 from gamedata.compendium import compendium
-from lib import errors
+from lib import elasticsearch, errors
 from lib.auth import requires_auth
 from lib.discord import discord_token_for, get_user_info
 from lib.redisIO import RedisIO
@@ -104,6 +104,7 @@ app.register_blueprint(workshop, url_prefix="/workshop")
 errors.register_error_handlers(app)
 
 compendium.reload(mdb)
+elasticsearch.init()
 
 if __name__ == '__main__':
     app.run()

--- a/docker/config-development.py
+++ b/docker/config-development.py
@@ -19,3 +19,6 @@ DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
 # site auth
 JWT_SECRET = os.getenv('JWT_SECRET')
+
+# AWS stuff
+ELASTICSEARCH_ENDPOINT = os.getenv('ELASTICSEARCH_ENDPOINT')

--- a/docker/config-production.py
+++ b/docker/config-production.py
@@ -17,3 +17,6 @@ DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
 # site auth
 JWT_SECRET = os.getenv('JWT_SECRET')
+
+# AWS stuff
+ELASTICSEARCH_ENDPOINT = os.getenv('ELASTICSEARCH_ENDPOINT')

--- a/lib/elasticsearch.py
+++ b/lib/elasticsearch.py
@@ -1,0 +1,45 @@
+import requests
+
+import config
+
+
+def init():
+    """Various things to run on application init."""
+    if not config.ELASTICSEARCH_ENDPOINT:
+        return
+    ensure_indices_exist()
+
+
+def ensure_indices_exist():
+    # alias workshop indices
+    requests.put(
+        f"{config.ELASTICSEARCH_ENDPOINT}/workshop_collections",
+        json={
+            "mappings": {
+                "properties": {
+                    "name": {"type": "text"},
+                    "description": {"type": "text"},
+                    "tags": {"type": "keyword"},
+                    "publish_state": {"type": "keyword"},
+                    "num_subscribers": {"type": "integer"},
+                    "num_guild_subscribers": {"type": "integer"},
+                    "last_edited": {"type": "date"},
+                    "created_at": {"type": "date"}
+                }
+            }
+        }
+    )
+
+    requests.put(
+        f"{config.ELASTICSEARCH_ENDPOINT}/workshop_events",
+        json={
+            "mappings": {
+                "properties": {
+                    "type": {"type": "keyword"},
+                    "object_id": {"type": "keyword"},
+                    "timestamp": {"type": "date"},
+                    "user_id": {"type": "keyword"}
+                }
+            }
+        }
+    )

--- a/lib/elasticsearch.py
+++ b/lib/elasticsearch.py
@@ -38,7 +38,8 @@ def ensure_indices_exist():
                     "type": {"type": "keyword"},
                     "object_id": {"type": "keyword"},
                     "timestamp": {"type": "date"},
-                    "user_id": {"type": "keyword"}
+                    "user_id": {"type": "keyword"},
+                    "sub_score": {"type": "integer"}
                 }
             }
         }

--- a/workshop/collection.py
+++ b/workshop/collection.py
@@ -2,11 +2,15 @@ import abc
 import collections
 import datetime
 import enum
+import json
 
+import requests
 from bson import ObjectId
 from flask import current_app
 
+import config
 from lib.errors import NotAllowed
+from lib.utils import HelperEncoder
 from workshop.errors import CollectableNotFound, CollectionNotFound
 from workshop.mixins import EditorMixin, GuildActiveMixin, SubscriberMixin
 
@@ -165,6 +169,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         inst = cls(None, name, description, image, user_id, [], [], PublicationState.PRIVATE, 0, 0, now, now, [])
         result = current_app.mdb.workshop_collections.insert_one(inst.to_dict())
         inst.id = result.inserted_id
+        inst.update_elasticsearch()
         return inst
 
     def update_info(self, name: str, description: str, image):
@@ -184,6 +189,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         self.description = description
         self.image = image
         self.last_edited = datetime.datetime.now()
+        self.update_elasticsearch()
 
     def delete(self):
         # do not allow deletion of published collections
@@ -200,6 +206,9 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         current_app.mdb.workshop_collections.delete_one(
             {"_id": self.id}
         )
+
+        # delete from elasticsearch
+        requests.delete(f"{config.ELASTICSEARCH_ENDPOINT}/workshop_collections/_doc/{str(self.id)}")
 
     def update_edit_time(self):
         current_app.mdb.workshop_collections.update_one(
@@ -242,6 +251,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         )
         self.publish_state = new_state
         self.last_edited = datetime.datetime.now()
+        self.update_elasticsearch()
 
     def create_alias(self, name, docs):
         code = "echo Hello world!"
@@ -270,6 +280,8 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
             {"type": {"$in": ["subscribe", "server_active"]}, "object_id": self.id},
             {"$push": {"alias_bindings": new_binding}}
         )
+
+        self.update_elasticsearch()
 
         return inst
 
@@ -301,6 +313,8 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
             {"$push": {"snippet_bindings": new_binding}}
         )
 
+        self.update_elasticsearch()
+
         return inst
 
     def add_tag(self, tag: str):
@@ -319,6 +333,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         )
         self.tags.append(tag)
         self.last_edited = datetime.datetime.now()
+        self.update_elasticsearch()
 
     def remove_tag(self, tag: str):
         """Removes a tag from this collection. Does nothing if the tag is not in the collection."""
@@ -334,6 +349,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
         )
         self.tags.remove(tag)
         self.last_edited = datetime.datetime.now()
+        self.update_elasticsearch()
 
     # bindings
     def _generate_default_alias_bindings(self):
@@ -407,7 +423,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
                 {"$inc": {"num_subscribers": 1}}
             )
             # log subscribe event
-            current_app.mdb.analytics_alias_events.insert_one(
+            self.log_event(
                 {"type": "subscribe", "object_id": self.id, "timestamp": datetime.datetime.utcnow(), "user_id": user_id}
             )
 
@@ -423,7 +439,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
             {"$inc": {"num_subscribers": -1}}
         )
         # log unsub event
-        current_app.mdb.analytics_alias_events.insert_one(
+        self.log_event(
             {"type": "unsubscribe", "object_id": self.id, "timestamp": datetime.datetime.utcnow(), "user_id": user_id}
         )
 
@@ -458,7 +474,7 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
                 {"$inc": {"num_guild_subscribers": 1}}
             )
             # log sub event
-            current_app.mdb.analytics_alias_events.insert_one(
+            self.log_event(
                 {"type": "server_subscribe", "object_id": self.id, "timestamp": datetime.datetime.utcnow(),
                  "user_id": invoker_id}
             )
@@ -475,9 +491,27 @@ class WorkshopCollection(SubscriberMixin, GuildActiveMixin, EditorMixin):
             {"$inc": {"num_guild_subscribers": -1}}
         )
         # log unsub event
-        current_app.mdb.analytics_alias_events.insert_one(
+        self.log_event(
             {"type": "server_unsubscribe", "object_id": self.id, "timestamp": datetime.datetime.utcnow(),
              "user_id": invoker_id}
+        )
+
+    def update_elasticsearch(self):
+        """POSTs the latest version of this collection to ElasticSearch (fire-and-forget)."""
+        requests.post(
+            f"{config.ELASTICSEARCH_ENDPOINT}/workshop_collections/_doc/{str(self.id)}",
+            data=json.dumps(self.to_dict(), cls=HelperEncoder),
+            headers={"Content-Type": "application/json"}
+        )
+
+    @staticmethod
+    def log_event(event):
+        """Logs the event and pushes it to ElasticSearch."""
+        current_app.mdb.analytics_alias_events.insert_one(event)
+        requests.post(
+            f"{config.ELASTICSEARCH_ENDPOINT}/workshop_events/_doc",
+            data=json.dumps(event, cls=HelperEncoder),
+            headers={"Content-Type": "application/json"}
         )
 
 


### PR DESCRIPTION
Since AWS DocumentDB doesn't support MongoDB's text index (and other features like the `$out` aggregation stage), we have to use ElasticSearch to do text search queries.

Depends on avrae/avrae-terraform#56