### PR TITLE
Alias Workshop Moderation Endpoints

### DIFF
--- a/lib/auth.py
+++ b/lib/auth.py
@@ -20,7 +20,7 @@ def requires_auth(func):
         try:
             the_jwt = request.headers['Authorization']
         except KeyError:
-            return error(403, "missing credentials")
+            return error(401, "missing credentials")
 
         try:
             uinfo = jwt.decode(the_jwt, config.JWT_SECRET, algorithms='HS256', issuer='avrae.io', audience='avrae.io',

--- a/lib/auth.py
+++ b/lib/auth.py
@@ -1,7 +1,7 @@
 import functools
 
 import jwt
-from flask import request
+from flask import current_app, request
 
 import config
 from lib.discord import UserInfo
@@ -53,3 +53,27 @@ def maybe_auth(func):
         return requires_auth(func)(*args, **kwargs)
 
     return inner
+
+
+def requires_user_permissions(*required_permissions):
+    """
+    A wrapper that ensures the user is authenticated and that the user has the given permissions
+    (as defined by the user_permissions collection) before running the inner.
+    If the user does not have all of the required permissions, returns 403.
+    Otherwise, calls the inner with the user as the first argument.
+    """
+
+    def wrapper(func):
+        @functools.wraps(func)
+        @requires_auth
+        def inner(user, *args, **kwargs):
+            user_permissions = current_app.mdb.user_permissions.find_one({"id": user.id})
+            if user_permissions is None:
+                return error(403, "User has no permissions")
+            elif not all(user_permissions.get(p) for p in required_permissions):
+                return error(403, f"Missing one or more permissions: {required_permissions!r}")
+            return func(user, *args, **kwargs)
+
+        return inner
+
+    return wrapper


### PR DESCRIPTION
### Summary
Adds Alias Workshop moderation endpoints to allow Avrae moderators to bypass checks and manage collections on the workshop. Currently, there is no matching UI - the HTTP requests have to be made manually.

Adds the `user_permissions` collection, a map of Discord user ID (str) to their granted permissions in Avrae (e.g. `{"id": "187421759484592128", "moderator": true}`).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
