### PR TITLE
2021w49: APIResponse refactor, IEffect parenting, Attack validation

### DIFF
--- a/blueprints/characters.py
+++ b/blueprints/characters.py
@@ -1,10 +1,12 @@
 import json
+from typing import Optional
 
 from flask import Blueprint, current_app, request
+from pydantic import BaseModel, Field, ValidationError, constr
 
 from lib.auth import requires_auth
 from lib.utils import error, jsonify, success
-from lib.validation import is_valid_automation
+from lib.validation import Automation, str1024, str255
 
 characters = Blueprint('characters', __name__)
 
@@ -19,9 +21,13 @@ def character_list(user):
 @characters.route('/meta', methods=["GET"])
 @requires_auth
 def meta(user):
-    data = list(current_app.mdb.characters.find({"owner": user.id},
-                                                ["upstream", "active", "name", "description", "image", "levels",
-                                                 "import_version", "overrides"]))
+    data = list(
+        current_app.mdb.characters.find(
+            {"owner": user.id},
+            ["upstream", "active", "name", "description", "image", "levels",
+             "import_version", "overrides"]
+        )
+    )
     return jsonify(data)
 
 
@@ -29,8 +35,10 @@ def meta(user):
 @requires_auth
 def attacks(user, upstream):
     """Returns a character's overriden attacks."""
-    data = current_app.mdb.characters.find_one({"owner": user.id, "upstream": upstream},
-                                               ["overrides"])
+    data = current_app.mdb.characters.find_one(
+        {"owner": user.id, "upstream": upstream},
+        ["overrides"]
+    )
     return jsonify(data['overrides']['attacks'])
 
 
@@ -42,14 +50,14 @@ def put_attacks(user, upstream):
 
     # validation
     try:
-        _validate_attacks(the_attacks)
+        validated_attacks = [Attack.parse_obj(a) for a in the_attacks]
     except ValidationError as e:
         return error(400, str(e))
 
     # write
     response = current_app.mdb.characters.update_one(
         {"owner": user.id, "upstream": upstream},
-        {"$set": {"overrides.attacks": the_attacks}}
+        {"$set": {"overrides.attacks": [a.dict(exclude_none=True) for a in validated_attacks]}}
     )
 
     # respond
@@ -65,7 +73,7 @@ def validate_attacks():
         reqdata = [reqdata]
 
     try:
-        _validate_attacks(reqdata)
+        [Attack.parse_obj(a) for a in reqdata]
     except ValidationError as e:
         return error(400, str(e))
 
@@ -80,28 +88,16 @@ def srd_attacks():
 
 
 # ==== helpers ====
-class ValidationError(Exception):
-    pass
+class Attack(BaseModel):
+    name: constr(strip_whitespace=True, min_length=1, max_length=255)
+    automation: Automation
+    v: int = Field(alias="_v")
+    proper: Optional[bool]
+    verb: Optional[str255]
+    criton: Optional[int]
+    phrase: Optional[str1024]
+    thumb: Optional[str1024]
+    extra_crit_damage: Optional[str255]
 
-
-REQUIRED_ATTACK_KEYS = {"name", "automation", "_v"}
-OPTIONAL_ATTACK_KEYS = {"proper", "verb", "criton", "phrase", "thumb", "extra_crit_damage"}
-
-
-def _validate_attacks(the_attacks):
-    if not isinstance(the_attacks, list):
-        raise ValidationError("Attacks must be a list")
-
-    template = "Invalid attack ({0}): {1}"
-
-    for i, attack in enumerate(the_attacks):
-        if not isinstance(attack, dict):
-            raise ValidationError(template.format(i, "attack is not an object"))
-
-        keys = set(attack.keys())
-        if not (keys.issuperset(REQUIRED_ATTACK_KEYS) and keys.issubset(REQUIRED_ATTACK_KEYS | OPTIONAL_ATTACK_KEYS)):
-            raise ValidationError(template.format(i, "attack object missing keys"))
-
-        valid, why = is_valid_automation(attack['automation'])
-        if not valid:
-            raise ValidationError(template.format(i, f"invalid automation: {why}"))
+    def dict(self, *args, **kwargs):
+        return super().dict(*args, by_alias=True, **kwargs)

--- a/blueprints/characters.py
+++ b/blueprints/characters.py
@@ -57,7 +57,7 @@ def put_attacks(user, upstream):
     # write
     response = current_app.mdb.characters.update_one(
         {"owner": user.id, "upstream": upstream},
-        {"$set": {"overrides.attacks": [a.dict(exclude_none=True) for a in validated_attacks]}}
+        {"$set": {"overrides.attacks": [a.dict(exclude_none=True, exclude_defaults=True) for a in validated_attacks]}}
     )
 
     # respond
@@ -93,11 +93,11 @@ class Attack(BaseModel):
     automation: Automation
     v: int = Field(alias="_v")
     proper: Optional[bool]
-    verb: Optional[str255]
+    verb: Optional[str255] = ""  # these empty strings are here for exclude_defaults
     criton: Optional[int]
-    phrase: Optional[str1024]
-    thumb: Optional[str1024]
-    extra_crit_damage: Optional[str255]
+    phrase: Optional[str1024] = ""
+    thumb: Optional[str1024] = ""
+    extra_crit_damage: Optional[str255] = ""
 
     def dict(self, *args, **kwargs):
         return super().dict(*args, by_alias=True, **kwargs)

--- a/blueprints/homebrew/items.py
+++ b/blueprints/homebrew/items.py
@@ -6,7 +6,7 @@ from flask import Blueprint, current_app, request
 from pydantic import BaseModel, HttpUrl, ValidationError, constr
 
 from lib.auth import maybe_auth, requires_auth
-from lib.utils import jsonify
+from lib.utils import error, success
 from lib.validation import str1024, str255, str4096
 from .helpers import user_can_edit, user_can_view, user_editable, user_is_owner
 
@@ -19,13 +19,17 @@ def _is_owner(user, obj_id):
 
 
 def _can_view(user, obj_id):
-    return user_can_view(data_coll=current_app.mdb.packs, sub_coll=current_app.mdb.pack_subscriptions, user=user,
-                         obj_id=obj_id)
+    return user_can_view(
+        data_coll=current_app.mdb.packs, sub_coll=current_app.mdb.pack_subscriptions, user=user,
+        obj_id=obj_id
+    )
 
 
 def _can_edit(user, obj_id):
-    return user_can_edit(data_coll=current_app.mdb.packs, sub_coll=current_app.mdb.pack_subscriptions, user=user,
-                         obj_id=obj_id)
+    return user_can_edit(
+        data_coll=current_app.mdb.packs, sub_coll=current_app.mdb.pack_subscriptions, user=user,
+        obj_id=obj_id
+    )
 
 
 def _editable(user):
@@ -41,7 +45,7 @@ def user_packs(user):
         pack['numItems'] = len(pack['items'])
         pack['owner'] = str(pack['owner'])
         del pack['items']
-    return jsonify(data)
+    return success(data)
 
 
 @items.route('', methods=['POST'])
@@ -49,9 +53,9 @@ def user_packs(user):
 def new_pack(user):
     reqdata = request.json
     if reqdata is None:
-        return "No data found", 400
+        return error(400, "No data found")
     if 'name' not in reqdata:
-        return "Missing name field", 400
+        return error(400, "Missing name field")
     pack = {
         'name': reqdata['name'],
         'public': bool(reqdata.get('public', False)),
@@ -61,8 +65,8 @@ def new_pack(user):
         'items': []
     }
     result = current_app.mdb.packs.insert_one(pack)
-    data = {"success": True, "packId": str(result.inserted_id)}
-    return jsonify(data)
+    data = {"packId": str(result.inserted_id)}
+    return success(data)
 
 
 @items.route('/<pack>', methods=['GET'])
@@ -70,11 +74,11 @@ def new_pack(user):
 def get_pack(user, pack):
     data = current_app.mdb.packs.find_one({"_id": ObjectId(pack)})
     if data is None:
-        return "Pack not found", 404
+        return error(404, "Pack not found")
     if not _can_view(user, ObjectId(pack)):
-        return "You do not have permission to view this pack", 403
+        return error(403, "You do not have permission to view this pack")
     data['owner'] = str(data['owner'])
-    return jsonify(data)
+    return success(data)
 
 
 @items.route('/<pack>', methods=['PUT'])
@@ -82,44 +86,44 @@ def get_pack(user, pack):
 def put_pack(user, pack):
     reqdata = request.json
     if not _can_edit(user=user, obj_id=ObjectId(pack)):
-        return "You do not have permission to edit this pack", 403
+        return error(403, "You do not have permission to edit this pack")
 
     try:
         the_pack = Pack.parse_obj(reqdata)
     except ValidationError as e:
-        return str(e), 400
+        return error(400, str(e))
 
     current_app.mdb.packs.update_one({"_id": ObjectId(pack)}, {"$set": the_pack.dict(exclude_unset=True)})
-    return "Pack updated."
+    return success("Pack updated.")
 
 
 @items.route('/<pack>', methods=['DELETE'])
 @requires_auth
 def delete_pack(user, pack):
     if not _is_owner(user, ObjectId(pack)):
-        return "You do not have permission to delete this pack", 403
+        return error(403, "You do not have permission to delete this pack")
     current_app.mdb.packs.delete_one({"_id": ObjectId(pack)})
     current_app.mdb.pack_subscriptions.delete_many({"object_id": ObjectId(pack)})
-    return "Pack deleted."
+    return success("Pack deleted.")
 
 
 @items.route('/<pack>/editors', methods=['GET'])
 @requires_auth
 def get_pack_editors(user, pack):
     if not _can_view(user, ObjectId(pack)):
-        return "You do not have permission to view this pack", 403
+        return error(403, "You do not have permission to view this pack")
 
     data = [str(sd['subscriber_id']) for sd in
             current_app.mdb.pack_subscriptions.find({"type": "editor", "object_id": ObjectId(pack)})]
 
-    return jsonify(data)
+    return success(data)
 
 
 @items.route('/srd', methods=['GET'])
 def srd_items():
     with open('static/template-items.json') as f:
         _items = json.load(f)
-    return jsonify(_items)
+    return success(_items)
 
 
 # ==== validation ====

--- a/blueprints/homebrew/spells.py
+++ b/blueprints/homebrew/spells.py
@@ -6,7 +6,7 @@ from flask import Blueprint, current_app, request
 from pydantic import BaseModel, HttpUrl, ValidationError, conint, constr
 
 from lib.auth import maybe_auth, requires_auth
-from lib.utils import jsonify
+from lib.utils import error, success
 from lib.validation import Automation, str1024, str255, str4096
 from .helpers import user_can_edit, user_can_view, user_editable, user_is_owner
 
@@ -19,13 +19,17 @@ def _is_owner(user, obj_id):
 
 
 def _can_view(user, obj_id):
-    return user_can_view(data_coll=current_app.mdb.tomes, sub_coll=current_app.mdb.tome_subscriptions, user=user,
-                         obj_id=obj_id)
+    return user_can_view(
+        data_coll=current_app.mdb.tomes, sub_coll=current_app.mdb.tome_subscriptions, user=user,
+        obj_id=obj_id
+    )
 
 
 def _can_edit(user, obj_id):
-    return user_can_edit(data_coll=current_app.mdb.tomes, sub_coll=current_app.mdb.tome_subscriptions, user=user,
-                         obj_id=obj_id)
+    return user_can_edit(
+        data_coll=current_app.mdb.tomes, sub_coll=current_app.mdb.tome_subscriptions, user=user,
+        obj_id=obj_id
+    )
 
 
 def _editable(user):
@@ -41,7 +45,7 @@ def user_tomes(user):
         tome['numSpells'] = len(tome['spells'])
         tome['owner'] = str(tome['owner'])
         del tome['spells']
-    return jsonify(data)
+    return success(data)
 
 
 @spells.route('', methods=['POST'])
@@ -49,9 +53,9 @@ def user_tomes(user):
 def new_tome(user):
     reqdata = request.json
     if reqdata is None:
-        return "No data found", 400
+        return error(400, "No data found")
     if 'name' not in reqdata:
-        return "Missing name field", 400
+        return error(400, "missing name field")
     tome = {
         'name': reqdata['name'],
         'public': bool(reqdata.get('public', False)),
@@ -61,8 +65,8 @@ def new_tome(user):
         'spells': []
     }
     result = current_app.mdb.tomes.insert_one(tome)
-    data = {"success": True, "tomeId": str(result.inserted_id)}
-    return jsonify(data)
+    data = {"tomeId": str(result.inserted_id)}
+    return success(data)
 
 
 @spells.route('/<tome>', methods=['GET'])
@@ -70,11 +74,11 @@ def new_tome(user):
 def get_tome(user, tome):
     data = current_app.mdb.tomes.find_one({"_id": ObjectId(tome)})
     if data is None:
-        return "Tome not found", 404
+        return error(404, "Tome not found")
     if not _can_view(user, ObjectId(tome)):
-        return "You do not have permission to view this tome", 403
+        return error(403, "You do not have permission to view this tome")
     data['owner'] = str(data['owner'])
-    return jsonify(data)
+    return success(data)
 
 
 @spells.route('/<tome>', methods=['PUT'])
@@ -82,44 +86,44 @@ def get_tome(user, tome):
 def put_tome(user, tome):
     reqdata = request.json
     if not _can_edit(user, ObjectId(tome)):
-        return "You do not have permission to edit this tome", 403
+        return error(403, "You do not have permission to edit this tome")
 
     try:
         the_tome = Tome.parse_obj(reqdata)
     except ValidationError as e:
-        return str(e), 400
+        return error(400, str(e))
 
     current_app.mdb.tomes.update_one({"_id": ObjectId(tome)}, {"$set": the_tome.dict(exclude_unset=True)})
-    return "Tome updated."
+    return success("Tome updated.")
 
 
 @spells.route('/<tome>', methods=['DELETE'])
 @requires_auth
 def delete_tome(user, tome):
     if not _is_owner(user, ObjectId(tome)):
-        return "You do not have permission to delete this tome", 403
+        return error(403, "You do not have permission to edit this tome")
     current_app.mdb.tomes.delete_one({"_id": ObjectId(tome)})
     current_app.mdb.tome_subscriptions.delete_many({"object_id": ObjectId(tome)})
-    return "Tome deleted."
+    return success("Tome updated.")
 
 
 @spells.route('/<tome>/editors', methods=['GET'])
 @requires_auth
 def get_tome_editors(user, tome):
     if not _can_view(user, ObjectId(tome)):
-        return "You do not have permission to view this tome", 403
+        return error(403, "You do not have permission to view this tome")
 
     data = [str(sd['subscriber_id']) for sd in
             current_app.mdb.tome_subscriptions.find({"type": "editor", "object_id": ObjectId(tome)})]
 
-    return jsonify(data)
+    return success(data)
 
 
 @spells.route('/srd', methods=['GET'])
 def srd_spells():
     with open('static/template-spells.json') as f:
         _spells = json.load(f)
-    return jsonify(_spells)
+    return success(_spells)
 
 
 @spells.route('/validate', methods=['POST'])
@@ -131,8 +135,8 @@ def validate_import():
         try:
             Spell.parse_obj(spell)
         except ValidationError as e:
-            return str(e), 400
-    return jsonify({'success': True, 'result': "OK"})
+            return error(400, str(e))
+    return success({'result': "OK"})
 
 
 # ==== Validation ====

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -28,6 +28,12 @@ class AbilityReference(BaseModel):
     typeId: int
 
 
+def str_is_identifier(value: str):
+    if not value.isidentifier():
+        raise ValueError("value must be a valid identifier")
+    return value
+
+
 # ---- effects ----
 class Effect(BaseModel, abc.ABC):
     type: str
@@ -97,6 +103,10 @@ class IEffect(Effect):
     conc: Optional[bool]
     desc: Optional[str4096]
     stacking: Optional[bool]
+    save_as: Optional[str255]
+    parent: Optional[str255]
+
+    _save_as_identifier = validator("save_as", allow_reuse=True)(str_is_identifier)
 
 
 class Roll(Effect):
@@ -120,10 +130,7 @@ class SetVariable(Effect):
     higher: Optional[HigherLevels]
     onError: Optional[str255]
 
-    @validator('name', allow_reuse=True)
-    def name_should_be_identifier(cls, v: str):
-        assert v.isidentifier(), "must be a valid identifier"
-        return v
+    _name_identifier = validator("name", allow_reuse=True)(str_is_identifier)
 
 
 class Condition(Effect):


### PR DESCRIPTION
### Summary
- Refactors the Pack/Tome endpoints to return APIResponse<T> instead of just T
- Adds a Pack/Tome sharing endpoint
- Adds validation to ensure attack names are at least 1 character long
- Adds validation for IEffect parenting
- Fixes an issue where certain attack keys would save as empty string instead of being excluded
- Resolves avrae/avrae#1654
- Resolves avrae/avrae#1653

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
