### PR TITLE
chore: bump to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 ARG ENVIRONMENT=production
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can join the Avrae Development Discord [here](https://discord.gg/pQbd4s6)!
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.10+
 - MongoDB server
 - Redis server
 
@@ -23,8 +23,8 @@ Compose.
 1. Copy `docker/config-development.py` to `config.py`.
 2. The dev config should point to the services exposed by the Avrae docker-compose file. If necessary, set the
    environment variables `MONGO_URL` and `REDIS_URL` to override connection strings.
-3. Set the `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, and `DISCORD_BOT_TOKEN` environment variables to the values
-   for your application, found in the [Discord Developer Portal](https://discord.com/developers/applications).
+3. Set the `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, and `DISCORD_BOT_TOKEN` environment variables to the values for
+   your application, found in the [Discord Developer Portal](https://discord.com/developers/applications).
 4. Set the `JWT_SECRET` env var to any value of your choice.
 
 **Env Var Overview**
@@ -53,7 +53,6 @@ Workshop endpoints might have undefined behaviour.
 4. Run the app: `python -m flask run`.
 
 The service should now be accessible at http://localhost:5000.
-
 
 Should you have authentication errors and DB not loading locally, you can update line 38 in app.py to the below.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ sentry-sdk[flask]==1.0.0
 
 # transitive deps
 Werkzeug==1.0.1
+itsdangerous==2.0.1
 
 # build/other deps
 dnspython==2.1.0  # pymongo srv


### PR DESCRIPTION
### Summary
Bumps the version of Python the service runs on to 3.10. The `itsdangerous` dep was pinned to 2.0.1 since the 2.1.0 release is currently broken.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
