### PR TITLE
Use the existing constants instead of hardcoding limits

### DIFF
--- a/blueprints/customizations.py
+++ b/blueprints/customizations.py
@@ -41,8 +41,8 @@ def alias_update(user, name):
         return "Name cannot contain whitespace", 400
     if name in current_app.rdb.jget("default_commands", []):
         return "Alias is already built-in", 409
-    if len(data["commands"]) > 4000:
-        return "Alias commands must be less than 4KB", 400
+    if len(data["commands"]) > ALIAS_SIZE_LIMIT:
+        return f"Alias commands must be less than {ALIAS_SIZE_LIMIT:,} characters", 400
 
     current_app.mdb.aliases.update_one(
         {"owner": user.id, "name": name}, {"$set": {"commands": data["commands"]}}, upsert=True
@@ -78,8 +78,8 @@ def snippet_update(user, name):
         return "Snippet cannot be blank", 400
     if " " in name:
         return "Name cannot contain whitespace", 400
-    if len(data["snippet"]) > 2000:
-        return "Snippet must be less than 2KB", 400
+    if len(data["snippet"]) > SNIPPET_SIZE_LIMIT:
+        return f"Snippet must be less than {SNIPPET_SIZE_LIMIT:,} characters", 400
     if len(name) < 2:
         return "Name must be at least 2 characters", 400
 
@@ -115,8 +115,8 @@ def uvar_update(user, name):
         return "Missing value field", 400
     if not data["value"]:
         return "Value cannot be blank", 400
-    if len(data["value"]) > 4000:
-        return "Value must be less than 4KB", 400
+    if len(data["value"]) > UVAR_SIZE_LIMIT:
+        return f"Value must be less than {UVAR_SIZE_LIMIT:,} characters", 400
 
     current_app.mdb.uvars.update_one({"owner": user.id, "name": name}, {"$set": {"value": data["value"]}}, upsert=True)
     return "Uvar updated."
@@ -163,8 +163,8 @@ def gvar_new(user):
         return "No data found", 400
     if "value" not in data:
         return "Missing value field", 400
-    if len(data["value"]) > 100000:
-        return "Gvars must be less than 100KB", 400
+    if len(data["value"]) > GVAR_SIZE_LIMIT:
+        return f"Gvars must be less than {GVAR_SIZE_LIMIT:,} characters", 400
     key = str(uuid.uuid4())
     gvar = {
         "owner": user.id,
@@ -200,8 +200,8 @@ def gvar_update(user, key):
         return "Gvar not found", 404
     if gvar["owner"] != user.id and user.id not in gvar.get("editors", []):
         return "You do not have permission to edit this gvar", 403
-    if len(data["value"]) > 100000:
-        return "Gvars must be less than 100KB", 400
+    if len(data["value"]) > GVAR_SIZE_LIMIT:
+        return f"Gvars must be less than {GVAR_SIZE_LIMIT:,} characters", 400
     current_app.mdb.gvars.update_one({"key": key}, {"$set": {"value": data["value"]}})
     return "Gvar updated."
 

--- a/blueprints/customizations.py
+++ b/blueprints/customizations.py
@@ -4,6 +4,7 @@ from flask import Blueprint, current_app, request
 
 from lib.auth import requires_auth
 from lib.utils import jsonify
+from workshop.constants import SNIPPET_SIZE_LIMIT, ALIAS_SIZE_LIMIT, UVAR_SIZE_LIMIT, GVAR_SIZE_LIMIT
 
 customizations = Blueprint("customizations", __name__)
 


### PR DESCRIPTION
### Summary
Various api calls were using hard coded limits instead of the existing constants. This particularly affected Snippets, which had a general limit of 5,000 characters but was hard coded to only allow 2,000 characters.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
