### PR TITLE
Add gamedata/spells endpoint

### DIFF
--- a/blueprints/gamedata.py
+++ b/blueprints/gamedata.py
@@ -35,10 +35,12 @@ def get_limited_use():
     """Returns a list of valid entities for use in building an AbilityReference in the automation builder."""
     return success(compendium.raw_limiteduse)
 
+
 @gamedata.route("spells", methods=["GET"])
 def get_spells():
     """Returns a list of valid entities for use in building a Cast Spell node in the automation builder."""
-    return success(compendium.raw_spells)
+    return success({f"{t['name']} ({t['source']})": t["id"] for t in compendium.raw_spells})
+    
 
 @gamedata.route("describable", methods=["GET"])
 def get_describables():

--- a/blueprints/gamedata.py
+++ b/blueprints/gamedata.py
@@ -35,6 +35,10 @@ def get_limited_use():
     """Returns a list of valid entities for use in building an AbilityReference in the automation builder."""
     return success(compendium.raw_limiteduse)
 
+@gamedata.route("spells", methods=["GET"])
+def get_spells():
+    """Returns a list of valid entities for use in building an SpellSlotReference in the automation builder."""
+    return success(compendium.raw_spells)
 
 @gamedata.route("describable", methods=["GET"])
 def get_describables():

--- a/blueprints/gamedata.py
+++ b/blueprints/gamedata.py
@@ -37,7 +37,7 @@ def get_limited_use():
 
 @gamedata.route("spells", methods=["GET"])
 def get_spells():
-    """Returns a list of valid entities for use in building an SpellSlotReference in the automation builder."""
+    """Returns a list of valid entities for use in building a Cast Spell node in the automation builder."""
     return success(compendium.raw_spells)
 
 @gamedata.route("describable", methods=["GET"])

--- a/blueprints/gamedata.py
+++ b/blueprints/gamedata.py
@@ -39,7 +39,9 @@ def get_limited_use():
 @gamedata.route("spells", methods=["GET"])
 def get_spells():
     """Returns a list of valid entities for use in building a Cast Spell node in the automation builder."""
-    return success({f"{t['name']} ({t['source']})": t["id"] for t in compendium.raw_spells})
+    return success(
+        {f"{t['name']} ({t['source']})": t["id"] for t in compendium.raw_spells}
+    )
     
 
 @gamedata.route("describable", methods=["GET"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
         build:
             context: .
             dockerfile: Dockerfile-dev
-        container_name: avrae_io
+        container_name: avrae_service
         ports:
-            - "8000:8080"
+            - "58000:8000"
         environment:
             - NODE_ENV=development


### PR DESCRIPTION
This should have existed.
https://avrae.readthedocs.io/en/stable/automation_ref.html#CastSpell.id

### Summary
Add the endpoint for spells gamedata that should have existed according to the documentation. There is no other way to get this data, as gamedata/entitlements is incomplete when it comes to SRD spells.

### Checklist
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
